### PR TITLE
feat: increment user assertion's revision

### DIFF
--- a/datastore/database.go
+++ b/datastore/database.go
@@ -146,6 +146,10 @@ type Datastore interface {
 	SyncListTestLogs() ([]TestLog, error)
 	SyncDeleteTestLog(ID int) error
 	UpdateAllowedTestLog(ID int, authorization User) error
+
+	CreateLastRevisionTable() error
+	GetLastRevision(int, string) (int, error)
+	SaveLastRevision(int, string, int) error
 }
 
 // DB local database interface with our custom methods.

--- a/datastore/mock_database.go
+++ b/datastore/mock_database.go
@@ -28,7 +28,8 @@ import (
 
 // MockDB holds the successful mocks for the database
 type MockDB struct {
-	encryptedAuthKeyHash string
+	encryptedAuthKeyHash      string
+	userAssertionLastRevision map[string]int
 }
 
 // CreateModelTable mock for the create model table method
@@ -873,6 +874,26 @@ func (mdb *MockDB) HealthCheck() error {
 	return nil
 }
 
+func (mdb *MockDB) CreateLastRevisionTable() error {
+	mdb.userAssertionLastRevision = make(map[string]int)
+	return nil
+}
+
+func (mdb *MockDB) GetLastRevision(modelId string, userEmail string) (int, error) {
+	key := fmt.Sprintf("%s-%s", modelId, userEmail)
+	lastRevision, ok := mdb.userAssertionLastRevision[key]
+	if !ok {
+		lastRevision = 1
+	}
+	return lastRevision, nil
+}
+
+func (mdb *MockDB) SaveLastRevision(modelId string, userEmail string, lastRevision int) error {
+	key := fmt.Sprintf("%s-%s", modelId, userEmail)
+	mdb.userAssertionLastRevision[key] = lastRevision
+	return nil
+}
+
 // -----------------------------------------------------------------------------
 
 // ErrorMockDB holds the unsuccessful mocks for the database
@@ -1383,4 +1404,16 @@ func (mdb *ErrorMockDB) UpdateAllowedTestLog(ID int, authorization User) error {
 // HealthCheck mock to simulate failed HealthCheck
 func (mdb *ErrorMockDB) HealthCheck() error {
 	return errors.New("Health check failed")
+}
+
+func (mdb *ErrorMockDB) CreateLastRevisionTable() error {
+	return errors.New("MOCK error creating last revision table")
+}
+
+func (mdb *ErrorMockDB) GetLastRevision(modelId string, userEmail string) (int, error) {
+	return 1, errors.New("MOCK error getting last revision")
+}
+
+func (mdb *ErrorMockDB) SaveLastRevision(modelId string, userEmail string, lastRevision int) error {
+	return errors.New("MOCK error saving last revision")
 }

--- a/datastore/userassertionlastrevsion.go
+++ b/datastore/userassertionlastrevsion.go
@@ -1,0 +1,70 @@
+package datastore
+
+import (
+	"database/sql"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
+)
+
+const defaultUserAssertionRevision = 1
+
+const createUserAssertionLastRevisionTableSQL = `
+        CREATE TABLE IF NOT EXISTS lastrevision (
+                model_id        varchar(200) not null,
+                user_email      varchar(255) not null,
+                last_revision   int not null
+
+                CONSTRAINT lastrevision_pkey PRIMARY KEY ("model_id", "user_email")
+        );
+`
+
+type UserAssertionLastRevisionStore interface {
+	GetLastRevision(string, string) (int, error)
+	SaveLastRevision(string, string, int) error
+}
+
+const getLastRevisionSQL = `
+        SELECT last_revision
+        FROM lastrevision
+        WHERE model_id=$1 AND user_email=$2
+`
+
+const upsertLastRevisionSQL = `
+        INSERT INTO last_revision (model_id, user_email, last_revision)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (lastrevision_pkey) DO UPDATE SET last_revision = EXCLUDED.last_revision
+`
+
+func (db *DB) CreateLastRevisionTable() error {
+	_, err := db.Exec(createUserAssertionLastRevisionTableSQL)
+	return err
+}
+
+func (db *DB) GetLastRevision(modelId string, userEmail string) (int, error) {
+	row, err := db.QueryRow(getLastRevisionSQL, modelId, userEmail)
+	if err != nil {
+		log.Printf("Error retrieving user's assertion last revision: %v", err)
+		return 0, err
+	}
+	defer row.Close()
+
+	return db.rowToLastRevision(row)
+}
+
+func (db *DB) SaveLastRevision(modelId string, userEmail string, lastRevision int) error {
+	_, err := db.Exec(upsertLastRevisionSQL, modelId, userEmail, lastRevision)
+	if err != nil {
+		log.Printf("Error saving a new user's assertion last revision: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+func (db *DB) rowToLastRevision(row *sql.Row) (int, error) {
+	// The default is 1 because this was the Serial Vault's hardcoded value
+	// up until now
+	lastRevision := defaultUserAssertionRevision
+	err := row.Scan(&lastRevision)
+	return lastRevision, err
+}

--- a/manage/database.go
+++ b/manage/database.go
@@ -127,6 +127,9 @@ func UpdateDatabase() {
 
 		// Create the testlog table, if it does not exist
 		{datastore.Environ.DB.CreateTestLogTable, create, "testlog", false},
+
+                // Create table to track user assertion's last revision
+                {datastore.Environ.DB.CreateLastRevisionTable, create, "last-revision", false},
 	}
 
 	exec(operations)

--- a/service/assertion/handlers_user.go
+++ b/service/assertion/handlers_user.go
@@ -32,7 +32,6 @@ import (
 )
 
 const oneYearDuration = time.Duration(24*365) * time.Hour
-const userAssertionRevision = "1"
 
 // SystemUserRequest is the JSON version of the request to create a system-user assertion
 type SystemUserRequest struct {


### PR DESCRIPTION
The user acounts on Ubuntu Core devices can be created using User
Assertions. Much like other assertion types these are versioned using
the revision property. The revision of the new assertion must be greater
than the revision of the assertion on the system and if it is not then
such a new assertion is rejected.

Up until now the revision of the User Assertion, in Serial Vault, has
been hardcoded to the value 1. As a consequence it is not possible to
regenerate a user assertion for the same credentials that would work on
a system because of the revision field being the same.

This commit makes Serial Vault track the user assertion's revision in a
database. It uses the model id and user's email as a key.